### PR TITLE
Add `model` param to `StreamingSenseVoice`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv
+.vscode
+*.pyc

--- a/streaming_sensevoice/streaming_sensevoice.py
+++ b/streaming_sensevoice/streaming_sensevoice.py
@@ -32,8 +32,9 @@ class StreamingSenseVoice:
         beam_size: int = 3,
         contexts: List[str] = None,
         device: str = "cpu",
+        model: str = "iic/SenseVoiceSmall",
     ):
-        model, kwargs = SenseVoiceSmall.from_pretrained(model="iic/SenseVoiceSmall")
+        model, kwargs = SenseVoiceSmall.from_pretrained(model=model)
         model = model.to(device)
         model.eval()
         self.device = device


### PR DESCRIPTION
Add `model` param to `StreamingSenseVoice` to enable loading local models or quantized models.