### PR TITLE
FIX: `Could not infer dtype of NoneType` when running `realtime.py`

### DIFF
--- a/streaming_sensevoice/streaming_sensevoice.py
+++ b/streaming_sensevoice/streaming_sensevoice.py
@@ -102,6 +102,8 @@ class StreamingSenseVoice:
         features = self.fbank.get_lfr_frames(
             neg_mean=self.neg_mean, inv_stddev=self.inv_stddev
         )
+        if features is None:
+            return None
         for feature in torch.unbind(torch.tensor(features), dim=0):
             self.caches = torch.roll(self.caches, -1, dims=0)
             self.caches[-1, :] = feature


### PR DESCRIPTION
The exception is as follow.

```
Exception has occurred: RuntimeError
Could not infer dtype of NoneType
  File "D:\streaming_sensevoice.py", line 107, in streaming_inference
    for feature in torch.unbind(torch.tensor(features), dim=0):
  File "D:\realtime.py", line 72, in main
    for res in model.streaming_inference(speech_samples, is_last):
  File "D:\realtime.py", line 78, in <module>
    main()
RuntimeError: Could not infer dtype of NoneType
```